### PR TITLE
Potential fix for code scanning alert no. 4: Replacement of a substring with itself

### DIFF
--- a/webapp/vite.config.ts
+++ b/webapp/vite.config.ts
@@ -13,8 +13,7 @@ export default defineConfig({
       '/api': {
         target: 'http://localhost:7071',
         changeOrigin: true,
-        secure: false,
-        rewrite: (path) => path.replace(/^\/api/, '/api')
+        secure: false
       }
     }
   },


### PR DESCRIPTION
Potential fix for [https://github.com/richardthorek/fireBreakCalculator/security/code-scanning/4](https://github.com/richardthorek/fireBreakCalculator/security/code-scanning/4)

To fix the problem, determine the intended use for the rewrite function in the proxy configuration. Usually, when proxying API requests like `/api/*` to a backend server, you might want to strip or change the `/api` prefix. If the target backend expects requests without the `/api` prefix (i.e., `/api/foo` should become `/foo`), the rewrite function could remove the prefix. If the backend expects `/api` to be present, the rewrite function can simply return the path unchanged, or the rewrite function can be omitted entirely for clarity.

In general, the best-practice fix is to either:
- Remove the rewrite function entirely if no rewriting is required (i.e., the path should be proxied as-is).
- Or, if you intend to strip or modify the prefix, replace the rewrite function with one that does the correct transformation.

Since the current rewrite function is a no-op, and leaving it as such may cause confusion, the single best fix is to remove the rewrite key from the proxy config if no transformation is needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
