### PR TITLE
Potential fix for code scanning alert no. 3: Replacement of a substring with itself

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
         target: 'http://localhost:7071',
         changeOrigin: true,
         secure: false,
-        rewrite: (path) => path.replace(/^\/api/, '/api')
+        rewrite: (path) => path.replace(/^\/api/, '')
       }
     }
   }


### PR DESCRIPTION
Potential fix for [https://github.com/richardthorek/fireBreakCalculator/security/code-scanning/3](https://github.com/richardthorek/fireBreakCalculator/security/code-scanning/3)

To fix the problem, we should alter the path rewrite function so it correctly transforms the incoming URL path as intended. Typical use case here is to *remove* the `/api` prefix before forwarding to the backend, so that requests to `/api/foo` are proxied as `/foo`. To do this, change the replacement string to `''` (empty string) instead of `'/api'`. 

Edit the line in `vite.config.ts` at line 13 from:
```ts
rewrite: (path) => path.replace(/^\/api/, '/api')
```
to:
```ts
rewrite: (path) => path.replace(/^\/api/, '')
```

No new methods, definitions, or imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
