### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/azure-static-web-apps-nice-pond-0e6903d00.yml
+++ b/.github/workflows/azure-static-web-apps-nice-pond-0e6903d00.yml
@@ -1,4 +1,7 @@
 name: Azure Static Web Apps CI/CD
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/richardthorek/fireBreakCalculator/security/code-scanning/2](https://github.com/richardthorek/fireBreakCalculator/security/code-scanning/2)

To fix this issue, add an explicit `permissions:` block to the workflow. This can be added at the top level if you want it to apply to all jobs, or per-job to granularly control permissions. For this workflow, the deployed actions likely need read access to repository contents, and possibly `pull-requests: write` for posting PR comments (e.g., via the `repo_token` usage). The minimal recommended block at the workflow root is:
```yaml
permissions:
  contents: read
  pull-requests: write
```
This should be inserted just below the `name:` field and above the `on:` section (after line 1, before line 3). No existing code needs to be changed; simply insert the block. There are no imports or variable definitions required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
